### PR TITLE
Removed app service plan premium

### DIFF
--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -328,7 +328,8 @@ func getBasicFunctionAppAppSettings(d *pluginsdk.ResourceData, appServiceTier, e
 
 	// On consumption and premium plans include WEBSITE_CONTENT components, unless it's a Linux consumption plan
 	// (see https://github.com/Azure/azure-functions-python-worker/issues/598)
-	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
+	// if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
+	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium")) &&
 		!strings.EqualFold(d.Get("os_type").(string), "linux") {
 		return append(basicSettings, consumptionSettings...), nil
 	}

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -654,7 +654,8 @@ func getBasicFunctionAppSlotAppSettings(d *pluginsdk.ResourceData, appServiceTie
 
 	// On consumption and premium plans include WEBSITE_CONTENT components, unless it's a Linux consumption plan
 	// (see https://github.com/Azure/azure-functions-python-worker/issues/598)
-	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
+	// if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
+	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium")) &&
 		!strings.EqualFold(d.Get("os_type").(string), "linux") {
 		return append(basicSettings, consumptionSettings...)
 	}


### PR DESCRIPTION
Removed the changes made in the following as its applying to app service plan premium where it did not do so before. This leads to an issue where it complaints about WEBSITE_CONTENTSHARE not being set on existing resources.

https://github.com/hashicorp/terraform-provider-azurerm/pull/12553/files
https://github.com/hashicorp/terraform-provider-azurerm/pull/12778/files

https://github.com/hashicorp/terraform-provider-azurerm/pull/13218

Note: Says the changes went in, in provider 2.70.0 but I cannot see any mention of this in the release notes.
